### PR TITLE
Treat Windows 10's new 'Edge' browser distinct from MSIE

### DIFF
--- a/jquery.client.js
+++ b/jquery.client.js
@@ -182,9 +182,12 @@
 					version = match[1];
 				}
 			}
-			// And IE 12's different lies about not being IE
+			// And MS Edge's lies about being Chrome
+			//
+			// It's different enough from classic IE Trident engine that they do this
+			// to avoid getting caught by MSIE-specific browser sniffing.
 			if ( name === 'chrome' && ( match = ua.match( /\bedge\/([0-9\.]*)/ ) ) ) {
-				name = 'msie';
+				name = 'edge';
 				version = match[1];
 				layout = 'edge';
 				layoutversion = parseInt( match[1], 10 );

--- a/test/jquery.client.test.js
+++ b/test/jquery.client.test.js
@@ -80,6 +80,7 @@
 				}
 			},
 			// Internet Explorer 11 - Windows 8.1 x64 desktop UI
+			// same with classic IE browser on Windows 10
 			'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko': {
 				title: 'Internet Explorer 11',
 				platform: 'WOW64',
@@ -97,12 +98,30 @@
 					rtl: true
 				}
 			},
-			// Internet Explorer 12
-			'Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0': {
-				title: 'Internet Explorer 12',
-				platform: 'WOW64',
+			// Microsoft Edge - Windows 10 x64 (preview build 10074)
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0': {
+				title: 'Microsoft Edge 12',
+				platform: 'Win64',
 				profile: {
-					name: 'msie',
+					name: 'edge',
+					layout: 'edge',
+					layoutVersion: 12,
+					platform: 'win',
+					version: '12.0',
+					versionBase: '12',
+					versionNumber: 12
+				},
+				wikiEditor: {
+					ltr: true,
+					rtl: true
+				}
+			},
+			// Microsoft Edge - Windows 10 x86 (preview build 10074)
+			'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0': {
+				title: 'Microsoft Edge 12',
+				platform: 'Win32',
+				profile: {
+					name: 'edge',
 					layout: 'edge',
 					layoutVersion: 12,
 					platform: 'win',


### PR DESCRIPTION
The new 'Microsoft Edge' browser in Windows 10 (aka 'Project Spartan')
has an updated rendering engine which is much more compatibile with
web standards and drops a lot of old IE-specific behavior.

MS are also splitting it more distinctly from IE; early preview builds
included the Edge engine as an optional mode in IE which caused some
confusion; future builds are going to keep them distinct and IE will
be frozen at version 11 with the old Trident engine.

Detecting Edge as 'edge' 12 insted of 'msie' 12 should reduce bugs from
IE-specific workarounds and disablements in existing JS code.

MS browser team asks that we report any issues direct to them to make
sure Edge is as compatible as possible with standards and the behavior
of other major browsers.

Ref T97917 https://phabricator.wikimedia.org/T97917.
