### PR TITLE
Add special case for Firefox Mobile to avoid matching Android version number

### DIFF
--- a/jquery.client.js
+++ b/jquery.client.js
@@ -134,6 +134,11 @@
 			// Everything will be in lowercase from now on
 			ua = ua.toLowerCase();
 
+			// Firefox Mobile: Remove 'Android' identifier so it matches to 'Firefox' instead
+			if ( ua.match( /android/ ) && ua.match( /firefox/ ) ) {
+				ua = ua.replace( new RegExp( 'android' + versionSuffix ), '' );
+			}
+
 			// Extraction
 
 			if ( ( match = new RegExp( '(' + names.join( '|' ) + ')' ).exec( ua ) ) ) {

--- a/test/jquery.client.test.js
+++ b/test/jquery.client.test.js
@@ -523,7 +523,25 @@
 					rtl: true
 				}
 			},
-			// Firefox mobile
+			// Firefox mobile 13
+			'Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0': {
+				title: 'Firefox mobile 13',
+				platform: 'Mobile',
+				profile: {
+					name: 'firefox',
+					layout: 'gecko',
+					layoutVersion: 13,
+					platform: 'unknown',
+					version: '13.0',
+					versionBase: '13',
+					versionNumber: 13
+				},
+				wikiEditor: {
+					ltr: true,
+					rtl: true
+				}
+			},
+			// Firefox mobile 65
 			'Mozilla/5.0 (Android 8.0.0; Mobile; rv:65.0) Gecko/65.0 Firefox/65.0': {
 				title: 'Firefox mobile 65',
 				platform: 'Mobile',

--- a/test/jquery.client.test.js
+++ b/test/jquery.client.test.js
@@ -522,6 +522,24 @@
 					ltr: true,
 					rtl: true
 				}
+			},
+			// Firefox mobile
+			'Mozilla/5.0 (Android 8.0.0; Mobile; rv:65.0) Gecko/65.0 Firefox/65.0': {
+				title: 'Firefox mobile 65',
+				platform: 'Mobile',
+				profile: {
+					name: 'firefox',
+					layout: 'gecko',
+					layoutVersion: 65,
+					platform: 'unknown',
+					version: '65.0',
+					versionBase: '65',
+					versionNumber: 65
+				},
+				wikiEditor: {
+					ltr: true,
+					rtl: true
+				}
 			}
 		},
 		testMap = {


### PR DESCRIPTION
Fixes https://phabricator.wikimedia.org/T101483